### PR TITLE
Update gitops cluster identifier

### DIFF
--- a/cli-manifests/prpipeline.yaml
+++ b/cli-manifests/prpipeline.yaml
@@ -139,7 +139,7 @@ pipeline:
             environmentRef: dev
             deployToAll: false
             gitOpsClusters:
-              - identifier: podinfocluster
+              - identifier: gitopscluster
         tags: {}
         failureStrategies:
           - onFailure:
@@ -228,7 +228,7 @@ pipeline:
             environmentRef: prod
             deployToAll: false
             gitOpsClusters:
-              - identifier: podinfocluster
+              - identifier: gitopscluster
         tags: {}
         failureStrategies:
           - onFailure:


### PR DESCRIPTION
Matching the gitops cluster id from gitops-cluster.yaml, prpipeline.yaml should have gitops cluster id as `gitopscluster` rather than `podinfoclusters`.