### PR TITLE
Update service.yaml to match pipeline entity.

### DIFF
--- a/cli-manifests/service.yaml
+++ b/cli-manifests/service.yaml
@@ -1,6 +1,6 @@
 service:
-  name: podinfo
-  identifier: podinfo
+  name: podinfoservice
+  identifier: podinfoservice
   orgIdentifier: default
   projectIdentifier: default_project
   serviceDefinition:


### PR DESCRIPTION
pipeline YAML refers to this as `podinfoservice` whereas service.yaml has this as `podinfo`.

This PR updates service.yaml to match the entity name.