### PR TITLE
Remove variables that are no longer needed.

### DIFF
--- a/cli-manifests/prpipeline.yaml
+++ b/cli-manifests/prpipeline.yaml
@@ -109,24 +109,9 @@ pipeline:
                   timeout: 10m
                   spec:
                     variables:
-                      - name: cluster.name
-                        type: String
-                        value: <+input>
-                      - name: cluster.owner
-                        type: String
-                        value: <+input>
-                      - name: cluster.address
-                        type: String
-                        value: <+input>
-                      - name: cluster.namespace
-                        type: String
-                        value: <+input>
                       - name: asset_id
                         type: String
                         value: <+trigger.gitUser>-<+trigger.commitSha>
-                      - name: aws_account
-                        type: String
-                        value: <+input>
               - step:
                   type: MergePR
                   name: Merge PR
@@ -198,24 +183,9 @@ pipeline:
                   timeout: 10m
                   spec:
                     variables:
-                      - name: cluster.name
-                        type: String
-                        value: <+input>
-                      - name: cluster.owner
-                        type: String
-                        value: <+input>
-                      - name: cluster.address
-                        type: String
-                        value: <+input>
-                      - name: cluster.namespace
-                        type: String
-                        value: <+input>
                       - name: asset_id
                         type: String
                         value: <+trigger.gitUser>-<+trigger.commitSha>
-                      - name: aws_account
-                        type: String
-                        value: <+input>
               - step:
                   type: MergePR
                   name: Merge PR


### PR DESCRIPTION
Pipeline trigger no longer works with these variables as part of the step. Removing these variables since we don't change them in the workshop anyway.